### PR TITLE
fix unreachable code

### DIFF
--- a/dist/service.php
+++ b/dist/service.php
@@ -269,7 +269,7 @@ class service
 
         $addedHeaders = $this->getHeaderValue($headers);
 
-        if ($result === false) {
+        if (!$result) {
             throw new RuntimeException(curl_error($ch), curl_errno($ch));
         }
 


### PR DESCRIPTION
In if, the result of the substr function (which is always a string) is strictly compared with bool, which always false